### PR TITLE
Fix documentation on OAuth role mapping

### DIFF
--- a/docs/sources/auth/generic-oauth.md
+++ b/docs/sources/auth/generic-oauth.md
@@ -41,15 +41,17 @@ Grafana will attempt to determine the user's e-mail address by querying the OAut
 
 1. Check for the presence of an e-mail address via the `email` field encoded in the OAuth `id_token` parameter.
 2. Check for the presence of an e-mail address in the `attributes` map encoded in the OAuth `id_token` parameter. By default Grafana will perform a lookup into the attributes map using the `email:primary` key, however, this is configurable and can be adjusted by using the `email_attribute_name` configuration option.
-3. Add role info by setting `role_attribute_name` (defaults to  `role`). Need to be mapped as string attribute to userinfo
-4. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
-5. If no e-mail address is found in steps (1-3), then the e-mail address of the user is set to the empty string.
+3. Query the `/emails` endpoint of the OAuth provider's API (configured with `api_url`) and check for the presence of an e-mail address marked as a primary address.
+4. If no e-mail address is found in steps (1-3), then the e-mail address of the user is set to the empty string.
+
+Grafana will also attempt to do role mapping through OAuth based on the key in the setting `role_attribute_name` (defaults to `role`) where the role needs to be mapped as string attribute to userinfo.
 
 ## Set up OAuth2 with Okta
 
 First set up Grafana as an OpenId client "webapplication" in Okta. Then set the Base URIs to `https://<grafana domain>/` and set the Login redirect URIs to `https://<grafana domain>/login/generic_oauth`.
 
 Finally set up the generic oauth module like this:
+
 ```bash
 [auth.generic_oauth]
 name = Okta


### PR DESCRIPTION
As stated on PR [#17149](https://github.com/grafana/grafana/pull/17149#discussion_r299875313), I've updated the documentation to reflect the `Contributor`'s @alexanderzobnin suggestion on extracting the role mapping to its own section instead of being in the middle of the e-mail related topic.